### PR TITLE
chore(batched_report): remove alias, rename method

### DIFF
--- a/lib/resque/reports/common/batched_report.rb
+++ b/lib/resque/reports/common/batched_report.rb
@@ -94,10 +94,9 @@ module Resque
         # Internal: Порядок строк отчета
         #
         # Returns String (SQL)
-        def order
+        def order_by
           nil
         end
-        alias_method :order_by, :order
 
         # Internal: Фильтры отчета
         #
@@ -122,7 +121,7 @@ module Resque
           query.project(Arel.sql(select))
                .take(batch_size)
                .skip(offset)
-               .order(order)
+               .order(order_by)
                .to_sql
         end
       end


### PR DESCRIPTION
Удален алиас "order_by"
Переименован метод "order" на "order_by"

"order_by" звучит более "sql-но"